### PR TITLE
docs: fix simple typo, descibing -> describing

### DIFF
--- a/CVE-2017-8259/qmi_encdec.c
+++ b/CVE-2017-8259/qmi_encdec.c
@@ -304,7 +304,7 @@ static int qmi_encode_basic_elem(void *buf_dst, void *buf_src,
 
 /**
  * qmi_encode_struct_elem() - Encodes elements of struct data type
- * @ei_array: Struct info array descibing the struct element.
+ * @ei_array: Struct info array describing the struct element.
  * @buf_dst: Buffer to store the encoded information.
  * @buf_src: Buffer containing the elements to be encoded.
  * @elem_len: Number of elements, in the buf_src, to be encoded.
@@ -346,7 +346,7 @@ static int qmi_encode_struct_elem(struct elem_info *ei_array,
 
 /**
  * qmi_encode_string_elem() - Encodes elements of string data type
- * @ei_array: Struct info array descibing the string element.
+ * @ei_array: Struct info array describing the string element.
  * @buf_dst: Buffer to store the encoded information.
  * @buf_src: Buffer containing the elements to be encoded.
  * @out_buf_len: Available space in the encode buffer.
@@ -645,7 +645,7 @@ static int qmi_decode_basic_elem(void *buf_dst, void *buf_src,
 
 /**
  * qmi_decode_struct_elem() - Decodes elements of struct data type
- * @ei_array: Struct info array descibing the struct element.
+ * @ei_array: Struct info array describing the struct element.
  * @buf_dst: Buffer to store the decoded element.
  * @buf_src: Buffer containing the elements in QMI wire format.
  * @elem_len: Number of elements to be decoded.
@@ -691,7 +691,7 @@ static int qmi_decode_struct_elem(struct elem_info *ei_array, void *buf_dst,
 
 /**
  * qmi_decode_string_elem() - Decodes elements of string data type
- * @ei_array: Struct info array descibing the string element.
+ * @ei_array: Struct info array describing the string element.
  * @buf_dst: Buffer to store the decoded element.
  * @buf_src: Buffer containing the elements in QMI wire format.
  * @tlv_len: Total size of the encoded inforation corresponding to


### PR DESCRIPTION
There is a small typo in CVE-2017-8259/qmi_encdec.c.

Should read `describing` rather than `descibing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md